### PR TITLE
Retrieve the last updated date

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -9,7 +9,7 @@ module.exports = function(eleventyConfig) {
     }
 
     // Newest date in the collection
-    return dateToISO(collection[ collection.length - 1 ].date);
+    return dateToISO(new Date(Math.max(...collection.map(item => {return item.date})));
   });
 
   eleventyConfig.addNunjucksFilter("rssDate", dateObj => dateToISO(dateObj));


### PR DESCRIPTION
Original code gets the last updated date assuming the last item in the collection is the newest. This can be a problem if the collection is sorted reversely. This change makes the filter actually find the latest date among the collection.