### PR TITLE
Remove Luxon from date formatting for small speedup.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,13 +25,12 @@
   },
   "homepage": "https://github.com/11ty/eleventy-plugin-rss#readme",
   "devDependencies": {
-    "@11ty/eleventy": "^0.6.0",
+    "@11ty/eleventy": "^0.11.0",
     "ava": "^1.0.1"
   },
   "dependencies": {
     "debug": "^4.1.1",
-    "luxon": "^1.0.0",
-    "posthtml": "^0.11.2",
+    "posthtml": "^0.13.0",
     "posthtml-urls": "1.0.0"
   }
 }

--- a/src/dateToISO.js
+++ b/src/dateToISO.js
@@ -1,5 +1,26 @@
-const { DateTime } = require("luxon");
 
 module.exports = function(dateObj) {
-  return DateTime.fromJSDate(dateObj).toISO({ includeOffset: true, suppressMilliseconds: true });
+  let dateTime = dateObj.getTime();
+  let dateStr = dateObj.toString();
+  // Grab the Timezone offset from the date string
+  let rawTz = dateStr.split("GMT")[1];
+  let dir = rawTz.substring(0, 1);
+  let tz = rawTz.substring(1, rawTz.indexOf(" "));
+  let tzHours = tz.substring(0, 2);
+  let tzMinutes = tz.substring(2);
+  let tzOffsetMs = 60 * 1000 * ((parseInt(tzHours, 0) * 60) + 
+                                 parseInt(tzMinutes));
+  // This doesn't represent the actual date; we're just offseting to get
+  // correct formatting.
+  let offsetDate = new Date(dateTime);
+  switch (dir) {
+    case "-":
+      offsetDate.setTime(dateTime + tzOffsetMs);
+    default: 
+      offsetDate.setTime(dateTime - tzOffsetMs);
+  }
+
+  let offsetResult = offsetDate.toISOString().split(".")[0] + 
+                        `${dir}${tzHours}:${tzMinutes}`;
+  return offsetResult;
 }

--- a/test/htmlToAbsoluteUrlsTest.js
+++ b/test/htmlToAbsoluteUrlsTest.js
@@ -1,5 +1,5 @@
 import test from "ava";
-import htmlToAbsUrls from "../src/HtmlToAbsoluteUrls.js";
+import htmlToAbsUrls from "../src/htmlToAbsoluteUrls.js";
 
 test("Changes a link href", async t => {
   t.is((await htmlToAbsUrls(`<a href="#testanchor">Hello</a>`, "http://example.com/")).html, `<a href="#testanchor">Hello</a>`);


### PR DESCRIPTION
My blog wound up using the `rssDate` function pretty heavily and profiling showed it was slow; this PR removes Luxon, which was reliably taking 4+ms to format a single date, replacing it with dirty, dirty date object hijinks. The output should be identical.

Also fixes broken test import.