### PR TITLE
Don't transform data URIs

### DIFF
--- a/src/htmlToAbsoluteUrls.js
+++ b/src/htmlToAbsoluteUrls.js
@@ -16,6 +16,11 @@ module.exports = function(htmlContent, base) {
         return url;
       }
 
+      // data URIs
+      if( url.indexOf("data:") === 0 ) {
+        return url;
+      }
+
       return absoluteUrl(url, base);
     }
   };


### PR DESCRIPTION
Add a check in `htmlToAbsoluteUrls` to pass through data URIs un-transformed.

Resolves #18 