### PR TITLE
Updating version to be inline with other plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "homepage": "https://www.11ty.dev/docs/plugins/rss/",
   "peerDependencies": {
-    "@11ty/eleventy": "^0.11.0"
+    "@11ty/eleventy": ">=0.11.0"
   },
   "devDependencies": {
     "ava": "^3.15.0"


### PR DESCRIPTION
Hi here @zachleat!

Just seen that 11ty went through a security upgrade before 1.0.0 hits. Tried to update it and npm gave me a hard time since the version outlined here isn't in the range of `0.12.1`. I checked other plugins such as [syntax-highlighting](https://github.com/11ty/eleventy-plugin-syntaxhighlight/blob/master/package.json#L37) which was in range so I thought this could be updated so people could easier benefit from this new update.

Let me know if you need any other changes to this.

Thanks!