### PR TITLE
Update jsonfeed example to use v1.1 with authors.

### DIFF
--- a/sample/feed-json.njk
+++ b/sample/feed-json.njk
@@ -15,15 +15,17 @@
 }
 ---
 {
-  "version": "https://jsonfeed.org/version/1",
+  "version": "https://jsonfeed.org/version/1.1",
   "title": "{{ metadata.title }}",
   "home_page_url": "{{ metadata.url }}",
   "feed_url": "{{ metadata.feedUrl }}",
   "description": "{{ metadata.subtitle }}",
-  "author": {
-    "name": "{{ metadata.author.name }}",
-    "url": "{{ metadata.author.url }}"
-  },
+  "authors": [
+    {
+      "name": "{{ metadata.author.name }}",
+      "url": "{{ metadata.author.url }}"
+    }
+  ],
   "items": [
     {%- for post in collections.posts | reverse %}
     {%- set absolutePostUrl %}{{ post.url | url | absoluteUrl(metadata.url) }}{% endset -%}


### PR DESCRIPTION
* Update the jsonfeed example to use v1.1 with authors. author has been deprecated in v1.1 with the addition of authors to allow for multiple authors.
* [v1.1 documentation with deprecation/replacement details](https://www.jsonfeed.org/version/1.1/).