### PR TITLE
Fix JSON Feed example

### DIFF
--- a/sample/feed-json.11ty.js
+++ b/sample/feed-json.11ty.js
@@ -22,10 +22,12 @@ module.exports.render = async function({ permalink, metadata, collections, norma
     home_page_url: metadata.url,
     feed_url: this.absoluteUrl(this.url(permalink), metadata.url),
     description: metadata.subtitle,
-    author: {
-      name: metadata.author.name,
-      url: metadata.author.url,
-    },
+    authors: [
+      {
+        name: metadata.author.name,
+        url: metadata.author.url,
+      }
+    ],
     items: []
   };
 


### PR DESCRIPTION
Similar to #35, but more up to date with the repo. JSON Feed example is listed under the v1.1 spec but is using the deprecated `author` field instead of `authors`.