### PR TITLE
Fix a couple of RFC822 formatting issues

### DIFF
--- a/src/dateRfc822.js
+++ b/src/dateRfc822.js
@@ -1,4 +1,4 @@
-module.exports = function pubDateRFC822(value) {
+module.exports = function pubDateRFC822(value, timeZone = undefined) {
   const date = new Date(value);
   const options = {
     weekday: 'short',
@@ -9,14 +9,15 @@ module.exports = function pubDateRFC822(value) {
     hour: '2-digit',
     minute: '2-digit',
     second: '2-digit',
-    hour12: false,
+    hourCycle: 'h23',
 
-    timeZoneName: 'short',
+    timeZone: timeZone,
+    timeZoneName: 'longOffset',
   };
 
-  const formatedDate = new Intl.DateTimeFormat('en-US', options).format(date);
-  const [wkd, mmm, dd, yyyy, time, z] = formatedDate.replace(/([,\s+\-]+)/g, ' ').split(' ');
-  const tz = `${z}`.replace(/UTC/, 'GMT');
+  const formattedDate = new Intl.DateTimeFormat('en-US', options).format(date);
+  const [wkd, mmm, dd, yyyy, time, z] = formattedDate.replace(/([,\s]+)/g, ' ').split(' ');
+  const tz = z.replace(/GMT(?<sign>\+|\-)(?<hour>\d\d):(?<minute>\d\d)/, '$<sign>$<hour>$<minute>');
 
   return `${wkd}, ${dd} ${mmm} ${yyyy} ${time} ${tz}`;
 }

--- a/test/dateToRfc822.test.js
+++ b/test/dateToRfc822.test.js
@@ -10,15 +10,27 @@ test('parses date correctly (specified date)', (t) => {
   t.true(parsedDate.startsWith('Wed, 21 Oct 2015 07:28:02'));
 });
 
+test('formats midnight correctly', (t) => {
+  const date = new Date(2015, 9, 21, 0, 0, 0, 0);
+  const parsedDate = dateRfc822(date);
+  t.regex(parsedDate, /^Wed, 21 Oct 2015 00:00:00/);
+});
+
+test('formats numerical time zones correctly', (t) => {
+  const date = new Date("2025-05-24T01:00:00+11:00");
+  const parsedDate = dateRfc822(date, "America/New_York"); // Bit of a hack to force a specific timezone (default is system time zone)
+  t.regex(parsedDate, / \-0400$/);
+})
+
 test('parses dates correctly (open-ended)', (t) => {
   const d = new Date();
   const pubDate = dateRfc822(d);
 
   const rfc822_date = /^([MTWFS][\w]{2},) (\d{2}) ([JFMASOND][a-z]{2}) (\d{4})/;
   const rfc822_time = /( \d{2}:\d{2}:\d{2} )/;
-  const rfc822_zone = /([A-Z]{2,3})$/;
+  const rfc822_zone = /([A-Z]{2,3}|(\+|\-)\d{4})$/;
 
   t.regex(pubDate, rfc822_date); // Tue, 04 Jun 2024
   t.regex(pubDate, rfc822_time); // 04:02:01
-  t.regex(pubDate, rfc822_zone); // GMT (depends where test runs)
+  t.regex(pubDate, rfc822_zone); // GMT or ±1000 (depends where test runs)
 });


### PR DESCRIPTION
- Times between midnight and 1AM should begin with "00:", not "24:".
- When running in a non-GMT time zone, the formatted time should end in the relevant time zone offset (e.g. +1000), not "GMT".