### PR TITLE
Add an option to set the time zone for the RSS feed.

### DIFF
--- a/src/rssPlugin.js
+++ b/src/rssPlugin.js
@@ -18,7 +18,7 @@ export default function eleventyRssPlugin(eleventyConfig, options = {}) {
   // Dates
   eleventyConfig.addNunjucksFilter("getNewestCollectionItemDate", getNewestCollectionItemDate);
   eleventyConfig.addNunjucksFilter("dateToRfc3339", dateRfc3339);
-  eleventyConfig.addNunjucksFilter("dateToRfc822", dateRfc822);
+  eleventyConfig.addNunjucksFilter("dateToRfc822", (date) => dateRfc822(date, options.timeZone));
 
   // Deprecated in favor of the more efficient HTML <base> plugin bundled with Eleventy
   eleventyConfig.addNunjucksFilter("absoluteUrl", absoluteUrl);


### PR DESCRIPTION
This will have no effect on the Atom feed, which is always in UTC.

I have tested this with my own site to force my RSS feed to UTC ("GMT" according to RFC 822).