### PR TITLE
fix: handle collections with hyphens for RSS

### DIFF
--- a/src/virtualTemplate.js
+++ b/src/virtualTemplate.js
@@ -22,7 +22,7 @@ ${stylesheet ? `<?xml-stylesheet href="${stylesheet}" type="text/xsl"?>\n` : ""}
     <description>{{ metadata.subtitle }}</description>
     <language>{{ metadata.language or page.lang }}</language>
     {%- if metadata.icon %}<image>{{ metadata.icon }}</image>{%- endif %}
-    {%- for post in collections.${collection.name} | reverse | eleventyFeedHead(${collection.limit}) %}
+    {%- for post in collections['${collection.name}'] | reverse | eleventyFeedHead(${collection.limit}) %}
     {%- set absolutePostUrl = post.url | htmlBaseUrl(metadata.base) %}
     <item>
       <title>{{ post.data.title }}</title>

--- a/test/virtualTemplatesTest.js
+++ b/test/virtualTemplatesTest.js
@@ -50,3 +50,29 @@ test("RSS virtual templates plugin with `all`", async (t) => {
 	let [ feed ] = results.filter(entry => entry.outputPath.endsWith(".xml"));
 	t.truthy(feed.content.startsWith(`<?xml version="1.0" encoding="utf-8"?>`));
 });
+
+test("RSS virtual templates plugin with hyphenated collection name", async (t) => {
+	const { default: Eleventy } = await import("@11ty/eleventy");
+
+	let elev = new Eleventy("./test", "./test/_site", {
+		config: function (eleventyConfig) {
+			eleventyConfig.addTemplate("virtual.md", `# Hello`, { title: "Post Title", tags: ["posts-newest"] })
+
+			eleventyConfig.addPlugin(feedPlugin, {
+				type: "rss", // or "atom", "json"
+				outputPath: "/feed.xml",
+				collection: {
+					name: "posts-newest", // iterate over `collections.posts-newest`
+					limit: 10,            // 0 means no limit
+				},
+			});
+		},
+	});
+
+	let results = await elev.toJSON();
+
+	t.deepEqual(results.length, 2);
+	let [ feed ] = results.filter(entry => entry.outputPath.endsWith(".xml"));
+	t.truthy(feed.content.startsWith(`<?xml version="1.0" encoding="utf-8"?>`));
+	t.true(feed.content.includes("<title>Post Title</title>"));
+});


### PR DESCRIPTION
I ran into an issue where the RSS feed being generated was empty when using a collection named "posts-newest". Tracked it down in the code, wrote a test to cover the issue, and patched accordingly.